### PR TITLE
Change upstream match for network-manager-applet

### DIFF
--- a/server/upstream/upstream-packages-match.txt
+++ b/server/upstream/upstream-packages-match.txt
@@ -810,7 +810,7 @@ nemiver:
 neon:
 net6:
 netspeed_applet:gnome-netspeed-applet
-network-manager-applet:NetworkManager-gnome
+network-manager-applet:NetworkManager-applet
 nimbus:gtk2-metatheme-nimbus
 njb-sharp:
 notification-daemon:


### PR DESCRIPTION
We renamed NetworkManager-gnome to NetworkManager-applet.
Not ideal, but better than we had